### PR TITLE
Multi-target examples to net8.0 + net10.0

### DIFF
--- a/1_Essentials/11_Groups/Scaffold.Web.csproj
+++ b/1_Essentials/11_Groups/Scaffold.Web.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/11_Groups/Scaffold.Web.csproj
+++ b/1_Essentials/11_Groups/Scaffold.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/11_Groups/Scaffold.Web.csproj
+++ b/1_Essentials/11_Groups/Scaffold.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />

--- a/1_Essentials/12_MessageSizes/Scaffold.Web.csproj
+++ b/1_Essentials/12_MessageSizes/Scaffold.Web.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/12_MessageSizes/Scaffold.Web.csproj
+++ b/1_Essentials/12_MessageSizes/Scaffold.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/12_MessageSizes/Scaffold.Web.csproj
+++ b/1_Essentials/12_MessageSizes/Scaffold.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />

--- a/1_Essentials/13_HubContextOutsideHub/Scaffold.Web.csproj
+++ b/1_Essentials/13_HubContextOutsideHub/Scaffold.Web.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/13_HubContextOutsideHub/Scaffold.Web.csproj
+++ b/1_Essentials/13_HubContextOutsideHub/Scaffold.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/13_HubContextOutsideHub/Scaffold.Web.csproj
+++ b/1_Essentials/13_HubContextOutsideHub/Scaffold.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />

--- a/1_Essentials/14_HubLifecycle/Scaffold.Web.csproj
+++ b/1_Essentials/14_HubLifecycle/Scaffold.Web.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/14_HubLifecycle/Scaffold.Web.csproj
+++ b/1_Essentials/14_HubLifecycle/Scaffold.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/14_HubLifecycle/Scaffold.Web.csproj
+++ b/1_Essentials/14_HubLifecycle/Scaffold.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />

--- a/1_Essentials/15_Reconnection/Scaffold.Web.csproj
+++ b/1_Essentials/15_Reconnection/Scaffold.Web.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/15_Reconnection/Scaffold.Web.csproj
+++ b/1_Essentials/15_Reconnection/Scaffold.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/15_Reconnection/Scaffold.Web.csproj
+++ b/1_Essentials/15_Reconnection/Scaffold.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />

--- a/1_Essentials/16_DependencyInjection/Scaffold.Web.csproj
+++ b/1_Essentials/16_DependencyInjection/Scaffold.Web.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/16_DependencyInjection/Scaffold.Web.csproj
+++ b/1_Essentials/16_DependencyInjection/Scaffold.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/16_DependencyInjection/Scaffold.Web.csproj
+++ b/1_Essentials/16_DependencyInjection/Scaffold.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />

--- a/1_Essentials/1_BasicClientServer/Scaffold.Web.csproj
+++ b/1_Essentials/1_BasicClientServer/Scaffold.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/1_Essentials/2_Logging/Scaffold.Web.csproj
+++ b/1_Essentials/2_Logging/Scaffold.Web.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/2_Logging/Scaffold.Web.csproj
+++ b/1_Essentials/2_Logging/Scaffold.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/2_Logging/Scaffold.Web.csproj
+++ b/1_Essentials/2_Logging/Scaffold.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />

--- a/1_Essentials/5_ChoosingTransportType/Scaffold.Web.csproj
+++ b/1_Essentials/5_ChoosingTransportType/Scaffold.Web.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/5_ChoosingTransportType/Scaffold.Web.csproj
+++ b/1_Essentials/5_ChoosingTransportType/Scaffold.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/5_ChoosingTransportType/Scaffold.Web.csproj
+++ b/1_Essentials/5_ChoosingTransportType/Scaffold.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />

--- a/1_Essentials/7_CallingHubMethods/Scaffold.Web.csproj
+++ b/1_Essentials/7_CallingHubMethods/Scaffold.Web.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/7_CallingHubMethods/Scaffold.Web.csproj
+++ b/1_Essentials/7_CallingHubMethods/Scaffold.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/7_CallingHubMethods/Scaffold.Web.csproj
+++ b/1_Essentials/7_CallingHubMethods/Scaffold.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />

--- a/1_Essentials/8_ClientEvents/Scaffold.Web.csproj
+++ b/1_Essentials/8_ClientEvents/Scaffold.Web.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/8_ClientEvents/Scaffold.Web.csproj
+++ b/1_Essentials/8_ClientEvents/Scaffold.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/1_Essentials/8_ClientEvents/Scaffold.Web.csproj
+++ b/1_Essentials/8_ClientEvents/Scaffold.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />

--- a/2_Advanced/01-1 Client Connection Events/Scaffold.Web.csproj
+++ b/2_Advanced/01-1 Client Connection Events/Scaffold.Web.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/01-1 Client Connection Events/Scaffold.Web.csproj
+++ b/2_Advanced/01-1 Client Connection Events/Scaffold.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/01-1 Client Connection Events/Scaffold.Web.csproj
+++ b/2_Advanced/01-1 Client Connection Events/Scaffold.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />

--- a/2_Advanced/01-2 Server Connection Events/Scaffold.Web.csproj
+++ b/2_Advanced/01-2 Server Connection Events/Scaffold.Web.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/01-2 Server Connection Events/Scaffold.Web.csproj
+++ b/2_Advanced/01-2 Server Connection Events/Scaffold.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/01-2 Server Connection Events/Scaffold.Web.csproj
+++ b/2_Advanced/01-2 Server Connection Events/Scaffold.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />

--- a/2_Advanced/02_MessagePack/Scaffold.Web.csproj
+++ b/2_Advanced/02_MessagePack/Scaffold.Web.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.10" />
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/02_MessagePack/Scaffold.Web.csproj
+++ b/2_Advanced/02_MessagePack/Scaffold.Web.csproj
@@ -3,8 +3,8 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.7" />

--- a/2_Advanced/02_MessagePack/Scaffold.Web.csproj
+++ b/2_Advanced/02_MessagePack/Scaffold.Web.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/03_StronglyTypedHubs/Hubs/ViewHub.cs
+++ b/2_Advanced/03_StronglyTypedHubs/Hubs/ViewHub.cs
@@ -15,7 +15,7 @@ public class ViewHub : Hub<IHubClient>
     }
 }
 
-public interface IHubClient 
+public interface IHubClient
 {
-    Task NewViewCount(int viewCount);
+    Task ViewCountUpdate(int viewCount);
 }

--- a/2_Advanced/03_StronglyTypedHubs/Scaffold.Web.csproj
+++ b/2_Advanced/03_StronglyTypedHubs/Scaffold.Web.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/03_StronglyTypedHubs/Scaffold.Web.csproj
+++ b/2_Advanced/03_StronglyTypedHubs/Scaffold.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/03_StronglyTypedHubs/Scaffold.Web.csproj
+++ b/2_Advanced/03_StronglyTypedHubs/Scaffold.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />

--- a/2_Advanced/08-1_Authorization/08-1_Authorization.csproj
+++ b/2_Advanced/08-1_Authorization/08-1_Authorization.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <UserSecretsId>aspnet-_08_1_Authorization-7573CADC-6F5B-4C95-B641-A3619D31E295</UserSecretsId>
     <RootNamespace>_08_1_Authorization</RootNamespace>
   </PropertyGroup>
@@ -8,15 +8,22 @@
     <None Update="app.db" CopyToOutputDirectory="PreserveNewest" ExcludeFromSingleFile="true" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="WebpackTag" Version="1.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10" />
-    <PackageReference Include="WebpackTag" Version="1.0.0" />
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/08-1_Authorization/08-1_Authorization.csproj
+++ b/2_Advanced/08-1_Authorization/08-1_Authorization.csproj
@@ -11,12 +11,12 @@
     <PackageReference Include="WebpackTag" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.7" />

--- a/2_Advanced/08-1_Authorization/08-1_Authorization.csproj
+++ b/2_Advanced/08-1_Authorization/08-1_Authorization.csproj
@@ -19,11 +19,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/11_AzureSignalRService/11_1-DefaultModeWithASPNETCore/Scaffold.Web.csproj
+++ b/2_Advanced/11_AzureSignalRService/11_1-DefaultModeWithASPNETCore/Scaffold.Web.csproj
@@ -1,13 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.SignalR" Version="1.33.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.10" />
-    <PackageReference Include="Microsoft.Azure.SignalR" Version="1.28.0" />
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/11_AzureSignalRService/11_1-DefaultModeWithASPNETCore/Scaffold.Web.csproj
+++ b/2_Advanced/11_AzureSignalRService/11_1-DefaultModeWithASPNETCore/Scaffold.Web.csproj
@@ -6,8 +6,8 @@
     <PackageReference Include="Microsoft.Azure.SignalR" Version="1.33.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.7" />

--- a/2_Advanced/11_AzureSignalRService/11_1-DefaultModeWithASPNETCore/Scaffold.Web.csproj
+++ b/2_Advanced/11_AzureSignalRService/11_1-DefaultModeWithASPNETCore/Scaffold.Web.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/12_RedisBackplane/Scaffold.Web.csproj
+++ b/2_Advanced/12_RedisBackplane/Scaffold.Web.csproj
@@ -3,8 +3,8 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.7" />

--- a/2_Advanced/12_RedisBackplane/Scaffold.Web.csproj
+++ b/2_Advanced/12_RedisBackplane/Scaffold.Web.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.10" />
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/12_RedisBackplane/Scaffold.Web.csproj
+++ b/2_Advanced/12_RedisBackplane/Scaffold.Web.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/13_HostedServices/Scaffold.Web.csproj
+++ b/2_Advanced/13_HostedServices/Scaffold.Web.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/13_HostedServices/Scaffold.Web.csproj
+++ b/2_Advanced/13_HostedServices/Scaffold.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/13_HostedServices/Scaffold.Web.csproj
+++ b/2_Advanced/13_HostedServices/Scaffold.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />

--- a/2_Advanced/14_dotnetClient/DotNetClient/DotNetClient.csproj
+++ b/2_Advanced/14_dotnetClient/DotNetClient/DotNetClient.csproj
@@ -7,6 +7,6 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/14_dotnetClient/DotNetClient/DotNetClient.csproj
+++ b/2_Advanced/14_dotnetClient/DotNetClient/DotNetClient.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/14_dotnetClient/DotNetClient/DotNetClient.csproj
+++ b/2_Advanced/14_dotnetClient/DotNetClient/DotNetClient.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />

--- a/2_Advanced/14_dotnetClient/Server/Scaffold.Web.csproj
+++ b/2_Advanced/14_dotnetClient/Server/Scaffold.Web.csproj
@@ -8,8 +8,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/14_dotnetClient/Server/Scaffold.Web.csproj
+++ b/2_Advanced/14_dotnetClient/Server/Scaffold.Web.csproj
@@ -3,9 +3,9 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />

--- a/2_Advanced/14_dotnetClient/Server/Scaffold.Web.csproj
+++ b/2_Advanced/14_dotnetClient/Server/Scaffold.Web.csproj
@@ -1,13 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.10" />
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/15_MultipleHubConnections/Scaffold.Web.csproj
+++ b/2_Advanced/15_MultipleHubConnections/Scaffold.Web.csproj
@@ -8,8 +8,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/2_Advanced/15_MultipleHubConnections/Scaffold.Web.csproj
+++ b/2_Advanced/15_MultipleHubConnections/Scaffold.Web.csproj
@@ -3,9 +3,9 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />

--- a/2_Advanced/15_MultipleHubConnections/Scaffold.Web.csproj
+++ b/2_Advanced/15_MultipleHubConnections/Scaffold.Web.csproj
@@ -1,13 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.10" />
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,20 @@ services.AddSignalR(options =>
 - Examples demonstrate progression from simple to complex scenarios
 - Each example is self-contained and runnable independently
 
+## Development Conventions
+
+### Git Branch Naming
+All branches must follow the format `griffin/{jira-ticket-number}-{description}` (kebab-case description). Example: `griffin/SOS-1936-events-param-validation`. If multiple tickets ride in one branch, use the lowest/primary ticket number and reference the others in commit messages and the PR body.
+
+### C# / .NET Workflow
+If any `.cs` file is updated in the project, offer to run the build or run the tests — odds are something broke. The standard `dotnet run` from each example directory is the smoke test; the example projects don't ship with a test suite.
+
+### Microsoft Documentation Links
+When adding links to Microsoft pages (`learn.microsoft.com`, `docs.microsoft.com`, `azure.microsoft.com`, etc.), always append the MVP tracking parameter: `?WT.mc_id=DOP-MVP-4029061`.
+
+### RTK (Rust Token Killer)
+Prefer `rtk`-prefixed commands for token-heavy operations to reduce noise (e.g., `rtk dotnet build`, `rtk git status`, `rtk gh pr view`). RTK passes through unchanged when no dedicated filter exists, so it's always safe to prefix.
+
 ## Course Information
 - Course website: https://signalrmastery.com
 - Support: Available through course community

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,10 +135,9 @@ services.AddSignalR(options =>
 
 ## Important Notes
 
-- All examples multi-target **net8.0** and **net10.0** (the two currently-supported LTS frameworks). `dotnet run` defaults to net10.0; pass `--framework net8.0` to run on the prior LTS.
-- Requires the .NET 8 SDK and/or the .NET 10 SDK installed.
+- All examples multi-target **net8.0** and **net10.0** (the two currently-supported LTS frameworks). Because the projects are multi-TFM, every `dotnet run` / `dotnet watch` / `dotnet publish` invocation must include `--framework net10.0` or `--framework net8.0` — plain `dotnet run` will error with `"Your project targets multiple frameworks"`.
+- Requires the **.NET 10 SDK** (which also builds the `net8.0` target). A net8-only SDK cannot evaluate a project that declares `net10.0`. `global.json` at the repo root pins the SDK to 10.x via `rollForward: latestFeature`.
 - Workshop snapshots under `Presentations/RealTimeRevolution/` remain on net6 by design — they're time-travel artifacts of the original workshop and are excluded from Renovate via `ignorePaths`.
-- `dotnet watch` and `dotnet publish` require an explicit `--framework net10.0` (or `net8.0`) on multi-targeted projects.
 - Automatic dependency updates via Renovate
 - Examples demonstrate progression from simple to complex scenarios
 - Each example is self-contained and runnable independently
@@ -149,7 +148,7 @@ services.AddSignalR(options =>
 All branches must follow the format `griffin/{jira-ticket-number}-{description}` (kebab-case description). Example: `griffin/SOS-1936-events-param-validation`. If multiple tickets ride in one branch, use the lowest/primary ticket number and reference the others in commit messages and the PR body.
 
 ### C# / .NET Workflow
-If any `.cs` file is updated in the project, offer to run the build or run the tests — odds are something broke. The standard `dotnet run` from each example directory is the smoke test; the example projects don't ship with a test suite.
+If any `.cs` file is updated in the project, offer to run the build or run the tests — odds are something broke. The standard smoke test is `dotnet run --framework net10.0` (or `net8.0`) from each example directory; the example projects don't ship with a test suite.
 
 ### Microsoft Documentation Links
 When adding links to Microsoft pages (`learn.microsoft.com`, `docs.microsoft.com`, `azure.microsoft.com`, etc.), always append the MVP tracking parameter: `?WT.mc_id=DOP-MVP-4029061`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,10 @@ services.AddSignalR(options =>
 
 ## Important Notes
 
-- All examples use .NET 6 (upgraded from .NET 5)
+- All examples multi-target **net8.0** and **net10.0** (the two currently-supported LTS frameworks). `dotnet run` defaults to net10.0; pass `--framework net8.0` to run on the prior LTS.
+- Requires the .NET 8 SDK and/or the .NET 10 SDK installed.
+- Workshop snapshots under `Presentations/RealTimeRevolution/` remain on net6 by design — they're time-travel artifacts of the original workshop and are excluded from Renovate via `ignorePaths`.
+- `dotnet watch` and `dotnet publish` require an explicit `--framework net10.0` (or `net8.0`) on multi-targeted projects.
 - Automatic dependency updates via Renovate
 - Examples demonstrate progression from simple to complex scenarios
 - Each example is self-contained and runnable independently

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,10 @@ npm run i
 # Start Webpack (watch mode)
 npm run build
 
-# Run application
-dotnet run
+# Run application (multi-target — pick a TFM)
+dotnet run --framework net10.0
+# or, to run on the prior LTS:
+dotnet run --framework net8.0
 ```
 
 ### Utilities

--- a/Demos/todo-application/RealTimeTodo.Web/RealTimeTodo.Web.csproj
+++ b/Demos/todo-application/RealTimeTodo.Web/RealTimeTodo.Web.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.10" />
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/Demos/todo-application/RealTimeTodo.Web/RealTimeTodo.Web.csproj
+++ b/Demos/todo-application/RealTimeTodo.Web/RealTimeTodo.Web.csproj
@@ -3,8 +3,8 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="10.0.7" />

--- a/Demos/todo-application/RealTimeTodo.Web/RealTimeTodo.Web.csproj
+++ b/Demos/todo-application/RealTimeTodo.Web/RealTimeTodo.Web.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/Presentations/RealTimeRevolution/src/END/src.csproj
+++ b/Presentations/RealTimeRevolution/src/END/src.csproj
@@ -3,9 +3,6 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.36" />
   </ItemGroup>
 </Project>

--- a/Presentations/RealTimeRevolution/src/START/src.csproj
+++ b/Presentations/RealTimeRevolution/src/START/src.csproj
@@ -3,9 +3,6 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.36" />
   </ItemGroup>
 </Project>

--- a/Upgrade.ps1
+++ b/Upgrade.ps1
@@ -1,12 +1,3 @@
-# Get-ChildItem . -recurse -include *.csproj | upgrade-assistant --skip-backup --non-interactive upgrade $_.Name
-
-Write-Output "Iterating over all projects in folder"
-foreach ( $file in Get-ChildItem -recurse -include *.csproj)
-{
-    Write-Output "Upgrading project $file"
-    upgrade-assistant upgrade --skip-backup --non-interactive $file
-}
-
 Write-Output "Remove .clef files"
 Get-ChildItem . -recurse -include *.clef | remove-item
 

--- a/Upgrade.ps1
+++ b/Upgrade.ps1
@@ -5,7 +5,12 @@ Write-Output "Iterating over NPM packages"
 foreach ( $file in Get-ChildItem -recurse -include package.json | Where-Object {!($_.Directory -like "*node_modules*")} )
 {
     Write-Output $file
-    Set-Location $file.Directory -PassThru
-    ncu -u
-    npm install
+    Push-Location $file.Directory
+    try {
+        ncu -u
+        npm install
+    }
+    finally {
+        Pop-Location
+    }
 }

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.0",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,32 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "ignorePaths": [
+    "Presentations/**"
+  ],
+  "packageRules": [
+    {
+      "description": "Lock the net8.0 conditional package lines at major 8.x",
+      "matchManagers": ["nuget"],
+      "matchPackagePatterns": [
+        "^Microsoft\\.AspNetCore\\.",
+        "^Microsoft\\.EntityFrameworkCore",
+        "^Microsoft\\.Extensions\\."
+      ],
+      "matchCurrentVersion": "/^8\\./",
+      "allowedVersions": "<9.0.0"
+    },
+    {
+      "description": "Lock the net10.0 conditional package lines at major 10.x",
+      "matchManagers": ["nuget"],
+      "matchPackagePatterns": [
+        "^Microsoft\\.AspNetCore\\.",
+        "^Microsoft\\.EntityFrameworkCore",
+        "^Microsoft\\.Extensions\\."
+      ],
+      "matchCurrentVersion": "/^10\\./",
+      "allowedVersions": "<11.0.0"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Migrates the 23 SignalR example projects from single-target `net6.0` (out of support since Nov 2024) to multi-target `net10.0;net8.0`, the two currently-supported LTS frameworks. `dotnet run` defaults to net10; pass `--framework net8.0` for the prior LTS.
- Framework-coupled ASP.NET Core / EF Core / Identity packages are split into conditional `<ItemGroup>` blocks per TFM so each major matches the runtime.
- The two `Presentations/RealTimeRevolution/` workshop snapshots stay frozen on net6 (they're time-travel artifacts of the original workshop) but get NewtonsoftJson pinned at 6.0.36 so they actually compile again — Renovate had bumped them to 8.0.10 which dropped net6 support.
- Drops the now-redundant `Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers` from every project; bumps `Microsoft.Azure.SignalR` 1.28.0 → 1.33.0.
- One pre-existing source fix slipped in: `2_Advanced/03_StronglyTypedHubs/Hubs/ViewHub.cs` had an `IHubClient` method named `NewViewCount` while the hub called `Clients.All.ViewCountUpdate(int)` and the TS client listens on `"viewCountUpdate"`. Renamed the interface method to match. That example never built on net6 either.
- `renovate.json` gets `ignorePaths: Presentations/**` and packageRules locking the conditional 8.x and 10.x lines at their respective majors (otherwise Renovate would cross-major-bump the 8.x lines since it doesn't understand MSBuild conditions).
- `Upgrade.ps1`: dead `upgrade-assistant` loop removed. `CLAUDE.md`: documents the multi-target setup, `--framework` requirement for `dotnet watch`/`dotnet publish`, and SDK prerequisite.

## Test plan

- [x] All 23 modified projects build cleanly on both `net8.0` and `net10.0` (46/46) with 0 warnings on `08-1_Authorization` as the representative
- [x] Both frozen Presentations projects build on `net6.0` (warnings limited to expected NETSDK1138 EOL notice)
- [ ] Runtime smoke test in a browser for `1_Essentials/1_BasicClientServer` on both TFMs
- [ ] Runtime smoke test for `2_Advanced/02_MessagePack` on both TFMs
- [ ] Runtime smoke test for `2_Advanced/08-1_Authorization` (Identity + EF Core)
- [ ] Runtime smoke test for `2_Advanced/12_RedisBackplane` (requires local Redis)
- [ ] Runtime smoke test for `2_Advanced/11_AzureSignalRService` (requires Azure SignalR resource)
- [ ] Runtime smoke test for `Demos/todo-application/RealTimeTodo.Web`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Examples now multi-target .NET 8 and 10 with framework-specific package selection and a global SDK pin.
  * Removed deprecated upgrade-assistant analyzers; added Renovate rules to exclude presentations.
  * Simplified upgrade script and updated npm/package tooling flow.

* **Documentation**
  * Added guidance for multi-targeting, required SDK, and development conventions.

* **Bug Fixes**
  * Renamed a strongly-typed hub callback to align client/server calls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1kevgriff/SignalR-Mastery/pull/36)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->